### PR TITLE
Prevent trigger key presses from populating newly opened config inputs

### DIFF
--- a/internal/model/update.go
+++ b/internal/model/update.go
@@ -161,6 +161,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case key.Matches(msg, keys.Add):
 				m.projectForm = project.NewProjectForm()
 				m.State = stateProjectManage
+				return m, nil
 
 			case key.Matches(msg, keys.Delete):
 				if selectedItem := m.projectList.SelectedItem(); selectedItem != nil {
@@ -182,6 +183,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.TerminalInput.SetValue(m.config.DefaultTerminal)
 				m.TerminalInput.Focus()
 				m.State = stateTerminalConfig
+				return m, nil
 			}
 
 		case stateProjectManage:


### PR DESCRIPTION
### Motivation
- When opening the project add form or the terminal config from the project list, the same key event used to trigger the view (for example `a`) was propagated into the newly focused text input and inserted as content.

### Description
- Stop propagation of the triggering key by returning immediately after handling `keys.Add` and `keys.SetDefaultTerminal` in `StateProjectSelect`, implemented in `internal/model/update.go`.

### Testing
- Ran `go test ./...` which could not complete due to an unrelated pre-existing build error in `internal/resource/resource.go` (`fmt.Errorf` format mismatch), so tests for this change did not run to success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af765bc1408332ab5345052b96c8a9)